### PR TITLE
Update lib dependencies for Ubuntu 18.04

### DIFF
--- a/ubuntu.sh
+++ b/ubuntu.sh
@@ -106,11 +106,9 @@ sudo apt-get install -y \
   curl \
   git \
   libffi-dev \
-  libgdbm3 \
   libgdbm-dev \
   libncurses5-dev \
-  libreadline6 \
-  libreadline6-dev \
+  libreadline-dev \
   libssl-dev \
   libyaml-dev \
   openssl \


### PR DESCRIPTION
Some libraries were obsoleted by Ubuntu 18.04 LTS, so they were removed